### PR TITLE
Update server.lua to use vim.lsp.config

### DIFF
--- a/lua/fortran/server.lua
+++ b/lua/fortran/server.lua
@@ -1,17 +1,17 @@
 local M = {}
 
 M.start_server = function(opts)
-  local lsp = require("lspconfig")
   local capabilities = vim.lsp.protocol.make_client_capabilities()
 
   table.insert(opts.server_opts.args, 1, opts.server_opts.path)
 
-  lsp.fortls.setup({
+  vim.lsp.config('fortls', {
     capabilities = capabilities,
     settings = opts.server_opts.settings,
     filetypes = opts.server_opts.filetypes,
     cmd = opts.server_opts.cmd,
   })
+  vim.lsp.enable('fortls')
 end
 
 return M


### PR DESCRIPTION
This uses the new syntax for nvim 0.11.